### PR TITLE
Add @pure

### DIFF
--- a/src/fornberg.jl
+++ b/src/fornberg.jl
@@ -31,14 +31,14 @@ immutable LinearOperator{T<:Real,S<:SVector} <: AbstractLinearOperator{T}
     #         slen = dorder + aorder - 1
     #         new{T1, SVector{slen,T1}}(dorder, aorder, dim)
     # end
-    function LinearOperator(derivative_order::Int, approximation_order::Int, dimension::Int)
+    Base.@pure function LinearOperator(derivative_order::Int, approximation_order::Int, dimension::Int)
         dimension            = dimension
         stencil_length       = derivative_order + approximation_order - 1
         boundary_length      = derivative_order + approximation_order
         boundary_point_count = stencil_length - div(stencil_length,2) + 1
         grid_step            = one(T)
-        low_boundary_coefs   = Vector{T}[]
-        high_boundary_coefs  = Vector{T}[]
+        #low_boundary_coefs   = Vector{T}[]
+        #high_boundary_coefs  = Vector{T}[]
         stencil_coefs        = calculate_weights(derivative_order, zero(T),
                                grid_step .* collect(-div(stencil_length,2) : 1 : div(stencil_length,2)))
 


### PR DESCRIPTION
This seems to be "hyperpure" since the final output is always the `===` same given the inputs. Without `Base.@pure`, it's not able to infer the full type because in the result of a static vector is its size. With `Base.@pure` it should be able to fully infer the type.

@dextorious @shivin9 

Should double check that this does work as intended though, since it is very undocumented. Reference to an appropriate discussion:

https://discourse.julialang.org/t/pure-macro/3871/5

